### PR TITLE
Support x86_64 host and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ copied to the target generated image.
 The main build.sh should detect if you have a missing dependency and
 let you know, but besides this you will need the following:
 
-* ArchLinux installation running same architecture of target image.
+* One of the following:
+  - ArchLinux host running same architecture of target image.
+  - ArchLinux x86_64 host with static builds of qemu and binfmt setup.
 * User account with sudo priviliges.
 
 ## Usage
@@ -45,14 +47,14 @@ To generate a Odroid N2 image you would do:
 ./build.sh build n2
 ```
 
-This will set the environment by default to xfce, you can specify
+This will set the environment by default to minimal, you can specify
 a different environment by using the -e flag, for example:
 
 ```sh
-./build.sh build -e wayfire n2
+./build.sh build -e xfce n2
 ```
 
-Then the instructions on platform/n2.sh and env/wayfire.sh are
+Then the instructions on platform/n2.sh and env/xfce.sh are
 executed. By default the script will install some packages, you can
 take a look on env/base.sh for the defaults.
 

--- a/env/minimal.sh
+++ b/env/minimal.sh
@@ -14,14 +14,6 @@ env_pre_chroot() {
 # Called inside the chroot
 env_chroot_setup() {
     echo "Env chroot-setup..."
-
-    if pacman -Qi mesa-devel-git > /dev/null 2>&1 ; then
-        pacman -Rcs --noconfirm mesa-devel-git
-    fi
-
-    if pacman -Qi libva-mesa-driver > /dev/null 2>&1 ; then
-        pacman -Rcs --noconfirm libva-mesa-driver
-    fi
 }
 
 # Called after exiting the disk image chroot

--- a/platform/c4.sh
+++ b/platform/c4.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-NAME="ArchLinuxARM-odroid-n2-latest"
+NAME="ArchLinuxARM-aarch64-latest"
 IMAGE="ArchLinuxARM-odroid-c4"
 
 platform_variables() {
-    echo "WAYLAND: set to 1 to install mali wayland GL libraries instead of fbdev."
-    echo "DISABLE_MALIGL: set to 1 to disable installation of mali libraries."
-    echo "TOBETTER_KERNEL: set to 1 to use tobetter kernel branch."
-    echo "CHEWITT_KERNEL: set to 1 to use chewitt kernel branch."
+    echo "G12_KERNEL: set to 1 to use g12 kernel branch."
 }
 
 platform_pre_chroot() {
@@ -17,86 +14,38 @@ platform_pre_chroot() {
 platform_chroot_setup() {
     echo "Platform chroot-setup..."
 
-    # Kernel
-    yes | pacman -Rcs linux-odroid-n2
-    yes | pacman -Rcs uboot-odroid-n2
-
-    if [ "${CHEWITT_KERNEL}" = "1" ]; then
-        alarm_pacman linux-amlogic-512
-        alarm_pacman linux-amlogic-512-headers
-        alarm_pacman dkms
-    elif [ "${TOBETTER_KERNEL}" = "1" ]; then
-        alarm_pacman linux-odroid-512
-        alarm_pacman linux-odroid-512-headers
-        alarm_pacman dkms
-    else
+    if [ "${G12_KERNEL}" = "1" ]; then
+        yes | pacman -Rcs linux-aarch64
         alarm_pacman linux-odroid-g12
-        alarm_pacman linux-odroid-g12-headers
     fi
 
     # Updated uboot
-    alarm_pacman uboot-odroid-c4
-
-    # Audio support
-    alarm_pacman odroid-alsa
-
-    if [ "${DISABLE_MALIGL}" != "1" ]; then
-        if [ "${WAYLAND}" != "1" ]; then
-            alarm_pacman odroid-c4-libgl-fb
-            alarm_pacman odroid-gl4es
-        fi
-    else
-        # mesa git for panfrost
-        alarm_pacman mesa-devel-git
-
-        if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-            echo "MOZ_X11_EGL=1" >> /etc/environment
-        fi
-    fi
+    alarm_pacman uboot-tools
+    alarm_install_package uboot-odroid-c4
 
     # Customizations
     cp /mods/boot/boot-logo.alarm.bmp.gz /boot/boot-logo.bmp.gz
 
-    if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-        echo "Copy boot.ini adapted for mainline kernel..."
-        cp /mods/boot/boot.c4.mainline.ini /boot/boot.ini
-
-        if [ "${DISABLE_MALIGL}" = "1" ]; then
-            echo "Enable panfrost-performance service..."
-            cp /mods/etc/systemd/system/panfrost-performance.service /etc/systemd/system/
-            systemctl enable panfrost-performance
-        fi
-    else
-        echo "Copy boot.ini adapted for c4..."
-        cp /mods/boot/boot.c4.hardkernel.ini /boot/boot.ini
-    fi
+    echo "Enable panfrost-performance service..."
+    cp /mods/etc/systemd/system/panfrost-performance.service /etc/systemd/system/
+    systemctl enable panfrost-performance
 }
 
 platform_chroot_setup_exit() {
     echo "Platform chroot-setup-exit..."
-    # Install at last since this causes issues
-    if [ "${DISABLE_MALIGL}" != "1" ]; then
-        if [ "${WAYLAND}" = "1" ]; then
-            alarm_pacman odroid-c4-libgl-wl
-        fi
-    fi
-
-    cp /mods/etc/default/cpupower.c4 /etc/default/cpupower
 }
 
 platform_post_chroot() {
     echo "Platform post-chroot..."
 
-    if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-        # Wireless
-        alarm_yay_install rtl88xxau-aircrack-dkms-git
-    fi
-
     echo "Setting boot.ini UUID"
-    local loopname=$(echo "${LOOP}" | sed "s/\/dev\///g")
+    local loopname
+    loopname=$(echo "${LOOP}" | sed "s/\/dev\///g")
 
-    local uuidboot=$(lsblk -o uuid,name | grep ${loopname}p1 | awk "{print \$1}")
-    local uuidroot=$(lsblk -o uuid,name | grep ${loopname}p2 | awk "{print \$1}")
+    local uuidboot
+    uuidboot=$(lsblk -o uuid,name | grep "${loopname}p1" | awk "{print \$1}")
+    local uuidroot
+    uuidroot=$(lsblk -o uuid,name | grep "${loopname}p2" | awk "{print \$1}")
 
     sudo sed -i "s/root=\/dev\/mmcblk\${devno}p2/root=UUID=${uuidroot}/g" \
         root/boot/boot.ini
@@ -108,6 +57,6 @@ platform_post_chroot() {
         | sudo tee --append root/etc/fstab
 
     echo "Flashing U-Boot..."
-    sudo dd if=root/boot/u-boot.bin of=${LOOP} conv=fsync,notrunc bs=512 seek=1
+    sudo dd if=root/boot/u-boot.bin of="${LOOP}" conv=fsync,notrunc bs=512 seek=1
     sync
 }

--- a/platform/n2.sh
+++ b/platform/n2.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
-NAME="ArchLinuxARM-odroid-n2-latest"
+NAME="ArchLinuxARM-aarch64-latest"
 IMAGE="ArchLinuxARM-odroid-n2"
 
 platform_variables() {
-    echo "WAYLAND: set to 1 to install mali wayland GL libraries instead of fbdev."
-    echo "DISABLE_MALIGL: set to 1 to disable installation of mali libraries."
     echo "TOBETTER_KERNEL: set to 1 to use tobetter kernel branch."
-    echo "CHEWITT_KERNEL: set to 1 to use chewitt kernel branch."
 }
 
 platform_pre_chroot() {
@@ -17,92 +14,39 @@ platform_pre_chroot() {
 platform_chroot_setup() {
     echo "Platform chroot-setup..."
 
-    # Kernel
-    yes | pacman -Rcs linux-odroid-n2
-    yes | pacman -Rcs uboot-odroid-n2
-
-    if [ "${CHEWITT_KERNEL}" = "1" ]; then
-        alarm_pacman linux-amlogic-519
-        alarm_pacman linux-amlogic-519-headers
-        alarm_pacman dkms
-    elif [ "${TOBETTER_KERNEL}" = "1" ]; then
+    if [ "${TOBETTER_KERNEL}" = "1" ]; then
+        yes | pacman -Rcs linux-aarch64
         alarm_pacman linux-odroid-600
-        alarm_pacman linux-odroid-600-headers
-        alarm_pacman dkms
-    else
-        alarm_pacman linux-odroid-g12
-        alarm_pacman linux-odroid-g12-headers
     fi
 
     # Updated uboot
-    alarm_pacman uboot-odroid-n2plus
-
-    # Audio support
-    alarm_pacman odroid-alsa
-
-    if [ "${DISABLE_MALIGL}" != "1" ]; then
-        if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-            alarm_pacman dkms-mali-bifrost
-        fi
-
-        if [ "${WAYLAND}" != "1" ]; then
-            alarm_pacman odroid-n2-libgl-fb
-            alarm_pacman odroid-gl4es
-        fi
-    else
-        # mesa for panfrost
-        alarm_pacman mesa
-
-        if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-            echo "MOZ_X11_EGL=1" >> /etc/environment
-        fi
-    fi
+    alarm_pacman uboot-tools
+    alarm_install_package uboot-odroid-n2plus
 
     # Customizations
     cp /mods/boot/boot-logo.alarm.bmp.gz /boot/boot-logo.bmp.gz
     cp /mods/etc/udev/rules.d/99-n2-fan-trip-temp.rules /etc/udev/rules.d/
 
-    if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-        echo "Copy boot.ini adapted for mainline kernel..."
-        cp /mods/boot/boot.n2plus.mainline.ini /boot/boot.ini
-
-        if [ "${DISABLE_MALIGL}" = "1" ]; then
-            echo "Enable panfrost-performance service..."
-            cp /mods/etc/systemd/system/panfrost-performance.service /etc/systemd/system/
-            systemctl enable panfrost-performance
-        fi
-    else
-        echo "Copy boot.ini adapted for n2+..."
-        cp /mods/boot/boot.n2plus.hardkernel.ini /boot/boot.ini
-
-        echo "Enable startup modules..."
-        cp /mods/etc/modules-load.d/modules.n2.conf /etc/modules-load.d/modules.conf
-    fi
+    echo "Enable panfrost-performance service..."
+    cp /mods/etc/systemd/system/panfrost-performance.service /etc/systemd/system/
+    systemctl enable panfrost-performance
 }
 
 platform_chroot_setup_exit() {
     echo "Platform chroot-setup-exit..."
-    # Install at last since this causes issues
-    if [ "${DISABLE_MALIGL}" != "1" ]; then
-        if [ "${WAYLAND}" = "1" ]; then
-            alarm_pacman odroid-n2-libgl-wl
-        fi
-    fi
 }
 
 platform_post_chroot() {
     echo "Platform post-chroot..."
 
-    if [ "${TOBETTER_KERNEL}" = "1" ] || [ "${CHEWITT_KERNEL}" = "1" ]; then
-        # Wireless
-        alarm_yay_install rtl88xxau-aircrack-dkms-git
-    fi
-
     echo "Setting boot.ini UUID"
-    local loopname=$(echo "${LOOP}" | sed "s/\/dev\///g")
+    local loopname
+    loopname=$(echo "${LOOP}" | sed "s/\/dev\///g")
 
-    local uuidboot=$(lsblk -o uuid,name | grep ${loopname}p1 | awk "{print \$1}")
-    local uuidroot=$(lsblk -o uuid,name | grep ${loopname}p2 | awk "{print \$1}")
+    local uuidboot
+    uuidboot=$(lsblk -o uuid,name | grep "${loopname}p1" | awk "{print \$1}")
+    local uuidroot
+    uuidroot=$(lsblk -o uuid,name | grep "${loopname}p2" | awk "{print \$1}")
 
     sudo sed -i "s/root=\/dev\/mmcblk\${devno}p2/root=UUID=${uuidroot}/g" \
         root/boot/boot.ini
@@ -114,6 +58,6 @@ platform_post_chroot() {
         | sudo tee --append root/etc/fstab
 
     echo "Flashing U-Boot..."
-    sudo dd if=root/boot/u-boot.bin of=${LOOP} conv=fsync,notrunc bs=512 seek=1
+    sudo dd if=root/boot/u-boot.bin of="${LOOP}" conv=fsync,notrunc bs=512 seek=1
     sync
 }


### PR DESCRIPTION
* Use qemu + binfmt to support building the images on x86_64 systems.
* Make the minimal image the default.
* Increased boot partition to 512MB since kernels are now larger.
* Updated n2 and c4 platforms to use the standard linux-aarch64.
* Updated the n2 and c4 uboot packages with better handling of dtb files.
* Updated the archdroid repo mirrors.
* Uset NetworkManager instead of systemd-networkd for more reliable network startup and the ease of use cli tools.
* Drop the default installation of mesa-devel-git and removed it from packages repo (stable mesa is in enough good shape).
* Enable multiple make jobs on system makepkg.conf for building packages and then restore it to original.
* Only require curl and dropped wget.
* Install updated keyring packages before upgrading other system packages.
* Fixed some shell warnings reported by linter.
* Use packages repo to build and install packages directly.